### PR TITLE
add a trim function for each cell of the SEMRUSH csv scrapped because…

### DIFF
--- a/SemRush.php
+++ b/SemRush.php
@@ -209,7 +209,7 @@ class SemRush
 			{
 				if(isset($firstRow[$i]))
 				{
-					$r[$firstRow[$i]] = $row[$i];
+					$r[$firstRow[$i]] = trim($row[$i]);
 				}
 			}
 			$array[] = $r;


### PR DESCRIPTION
add a trim function for each cell of the SEMRUSH csv scrapped because… some cells finish by \r

for instance, the "url" field of the getOrganicKeywordsReport report
